### PR TITLE
Change the import order

### DIFF
--- a/iron-icons.html
+++ b/iron-icons.html
@@ -31,7 +31,6 @@ See [iron-iconset](#iron-iconset) and [iron-iconset-svg](#iron-iconset-svg) for 
 @demo demo/index.html
 -->
 
-<link rel="import" href="../iron-icon/iron-icon.html">
 <link rel="import" href="../iron-iconset-svg/iron-iconset-svg.html">
 <iron-iconset-svg name="icons" size="24">
 <svg><defs>
@@ -301,3 +300,4 @@ See [iron-iconset](#iron-iconset) and [iron-iconset-svg](#iron-iconset-svg) for 
 <g id="zoom-out"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14zM7 9h5v1H7z"/></g>
 </defs></svg>
 </iron-iconset-svg>
+<link rel="import" href="../iron-icon/iron-icon.html">


### PR DESCRIPTION
Ensures that <iron-icon> elements are not upgraded before the default icon set is defined.

The current order of operations is:

1. `iron-icons.html` is loaded
1. This causes `iron-icon.html` to be imported, blocking the rest of the execution
1. `iron-icon` is executed, upgrading any existing `<iron-icon>` elements
1. `iron-icons` then resumes, defining the default icon set

If you load your elements asynchronously this fails if an existing icon uses the default icon set. The element is upgraded before the icon set is defined. This gives an error about the icon set not being imported.