### PR TITLE
Update iron-icons.html

### DIFF
--- a/iron-icons.html
+++ b/iron-icons.html
@@ -22,9 +22,9 @@ Example using the directions-bus icon from the maps icon set:
     <iron-icon icon="maps:directions-bus"></iron-icon>
 
 
-See [iron-icon](#iron-icon) for more information about working with icons.
+See [iron-icon](./iron-icon) for more information about working with icons.
 
-See [iron-iconset](#iron-iconset) and [iron-iconset-svg](#iron-iconset-svg) for more information about how to create a custom iconset.
+See [iron-iconset](./iron-iconset) and [iron-iconset-svg](./iron-iconset-svg) for more information about how to create a custom iconset.
 
 @group Iron Elements
 @pseudoElement iron-icons


### PR DESCRIPTION
Fix links in documentation, at the very least they don't work in the element catalog and neither my 'fix' nor the current links work when you open the page in bower_components (bower_components links require `../iron-icon`, but I think the Element Catalog is more often used)