### PR TITLE
Fixes #80: Nested <dom-*> templates shouldn't be wrapped.

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -90,21 +90,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </style>
   </custom-style>
 
-  <dom-bind>
-    <template is="dom-bind" id="scope">
-      <dom-repeat>
-        <template is="dom-repeat" id="iconsetRepeat">
-          <h2>{{item.name}}</h2>
-          <dom-repeat class="set">
-            <template is="dom-repeat" items="{{getIconNames(item)}}">
-              <span class="container">
-                <iron-icon icon="{{item}}"></iron-icon>
-                <div>{{item}}</div>
-              </span>
-            </template>
-          </dom-repeat>
-        </template>
-      </dom-repeat>
+  <dom-bind id="scope">
+    <template is="dom-bind">
+      <template is="dom-repeat" id="iconsetRepeat">
+        <h2>{{item.name}}</h2>
+        <div class="set">
+          <template is="dom-repeat" items="{{getIconNames(item)}}">
+            <span class="container">
+              <iron-icon icon="{{item}}"></iron-icon>
+              <div>{{item}}</div>
+            </span>
+          </template>
+        </div>
+      </template>
     </template>
   </dom-bind>
 


### PR DESCRIPTION
Templates inside other <dom-*> templates should only use `is=` (no wrapper), even in 2.x . [?w=1](https://github.com/PolymerElements/iron-icons/pull/82/files?w=1)